### PR TITLE
Minor copy edit, statements -> principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!-- omit in toc -->
-# Tech core beliefs, our guiding statements for time to value; speed, quality, reliability and agility
+# Tech core beliefs, our guiding principles for time to value; speed, quality, reliability and agility
 
 This document was created on the belief that instead of making strict rules on how we build products and services in Unified Design @ Autodesk, we believe in alignment on how, by creating some guiding principles. We strongly believe that time to value is best served by autonomy and thereby letting our people choose the right tool for the job every time. In that we also say that we choose a little chaos over control and big platform architectures. 
 


### PR DESCRIPTION
I noticed that "statement" didn't really quite sound right. These are ideas, concepts or principles. There are many synonyms but we already use "principle" in the document, so let's use that! 😄 

If this merges, remember to adjust the 'About' by-line on the repository. It's on the top right on the repo's [home page](https://github.com/spacemakerai/unified-design-tech-core-beliefs)